### PR TITLE
Change module entry point from .mjs to .js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Bram Kaashoek",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "module": "dist/index.mjs",
+  "module": "dist/index.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
When importing the library, the entry point is not found